### PR TITLE
adhoc: change from or to use stdlib getenv

### DIFF
--- a/marquez_airflow/dag.py
+++ b/marquez_airflow/dag.py
@@ -35,8 +35,8 @@ class DAG(airflow.models.DAG):
         super().__init__(*args, **kwargs)
         self._marquez_dataset_cache = {}
         self._marquez_source_cache = {}
-        self.marquez_namespace = os.environ.get('MARQUEZ_NAMESPACE') or \
-            DAG.DEFAULT_NAMESPACE
+        self.marquez_namespace = os.getenv('MARQUEZ_NAMESPACE',
+                                           DAG.DEFAULT_NAMESPACE)
         self._job_id_mapping = JobIdMapping()
 
     def create_dagrun(self, *args, **kwargs):


### PR DESCRIPTION
Small readability to use `os.getenv` which has the built in fallback.  This is purely a readability gain.

https://docs.python.org/3/library/os.html#os.getenv