### PR TITLE
Fix log for run state transition

### DIFF
--- a/marquez_airflow/dag.py
+++ b/marquez_airflow/dag.py
@@ -359,9 +359,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                 f'Found job runs: {task_info}'
                 f'marquez_run_ids={marquez_job_run_ids} ')
 
-            state = 'UNKNOWN'
             if kwargs.get('success'):
-                state = 'COMPLETED'
                 for marquez_job_run_id in marquez_job_run_ids:
                     for task_id, task in self.task_dict.items():
                         if task_id == ti.task_id:
@@ -374,13 +372,18 @@ class DAG(airflow.models.DAG, LoggingMixin):
                                 marquez_job_run_id=marquez_job_run_id)
                     self.get_or_create_marquez_client(). \
                         mark_job_run_as_completed(run_id=marquez_job_run_id)
+                    self.log.info(
+                        f"Marked run '{marquez_job_run_id}' as COMPLETED "
+                        f"for task '{ti.task_id}'."
+                    )
             else:
-                state = 'FAILED'
                 for marquez_job_run_id in marquez_job_run_ids:
                     self.get_or_create_marquez_client().mark_job_run_as_failed(
-                        run_id=marquez_job_run_id)
-
-            self.log.info(f"Successfully marked run as '{state}' for task '{ti.task_id}'.")
+                        run_id=run_id)
+                    self.log.info(
+                        f"Marked run '{marquez_job_run_id}' as FAILED "
+                        f"for task '{ti.task_id}'."
+                    )
 
     def get_or_create_marquez_client(self):
         if not self._marquez_client:

--- a/marquez_airflow/dag.py
+++ b/marquez_airflow/dag.py
@@ -380,7 +380,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                     self.get_or_create_marquez_client().mark_job_run_as_failed(
                         run_id=marquez_job_run_id)
 
-        self.log.info(f'Marked job run(s) as {state}. {task_info}')
+            self.log.info(f"Successfully marked run as '{state}' for task '{ti.task_id}'.")
 
     def get_or_create_marquez_client(self):
         if not self._marquez_client:

--- a/marquez_airflow/dag.py
+++ b/marquez_airflow/dag.py
@@ -379,7 +379,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
             else:
                 for marquez_job_run_id in marquez_job_run_ids:
                     self.get_or_create_marquez_client().mark_job_run_as_failed(
-                        run_id=run_id)
+                        run_id=marquez_job_run_id)
                     self.log.info(
                         f"Marked run '{marquez_job_run_id}' as FAILED "
                         f"for task '{ti.task_id}'."


### PR DESCRIPTION
This PR cleans up the logs by removing the following exception:

```
ERROR - Failed to record task run state change: local variable 'state' referenced before assignment dag_id=new_food_deliveries
Traceback (most recent call last):
  File "/opt/bitnami/airflow/venv/lib/python3.6/site-packages/marquez_airflow/dag.py", line 181, in handle_callback
    ti, dagrun.run_id, **kwargs)
  File "/opt/bitnami/airflow/venv/lib/python3.6/site-packages/marquez_airflow/dag.py", line 383, in report_jobrun_change
    self.log.info(f'Marked job run(s) as {state}. {task_info}')
UnboundLocalError: local variable 'state' referenced before assignment
```